### PR TITLE
Look for key, not 'key'

### DIFF
--- a/stub.js
+++ b/stub.js
@@ -3,7 +3,7 @@
 var ms = {};
 
 function getItem (key) {
-  return 'key' in ms ? ms[key] : null;
+  return key in ms ? ms[key] : null;
 }
 
 function setItem (key, value) {


### PR DESCRIPTION
This corrects the stub for `getItem` to look for `key in ms` instead of `'key'`.
