### PR TITLE
Allow the local storage backend to be replaced.

### DIFF
--- a/local-storage.js
+++ b/local-storage.js
@@ -32,10 +32,17 @@ function clear () {
   return ls.clear();
 }
 
+function backend (store) {
+  store && (ls = store);
+
+  return ls;
+}
+
 accessor.set = set;
 accessor.get = get;
 accessor.remove = remove;
 accessor.clear = clear;
+accessor.backend = backend;
 accessor.on = tracking.on;
 accessor.off = tracking.off;
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -105,6 +105,21 @@ ls.set('baz', 'tar');
 ls.clear();
 ```
 
+## `ls.backend(store?)`
+
+If a `store` argument is provided, it sets the backend storage engine. Otherwise it returns the current backend.
+
+##### Example
+
+```js
+var ls = require('local-storage');
+
+ls.backend(sessionStorage);
+ls.set('baz', 'tar');
+/* close the tab, then reopen */
+ls.get('baz');
+```
+
 ## `ls.on(key, fn)`
 
 Listen for changes persisted against `key` on other tabs. Triggers `fn` when a change occurs, passing the following arguments.


### PR DESCRIPTION
Allow another storage engine to be specified. This is especially useful for specifying `sessionStorage` like `ls.backend(sessionStorage)`.
