### PR TITLE
Make it work inside iframe

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "localstorage",
   "main": "dist/local-storage.js",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "homepage": "https://github.com/bevacqua/local-storage",
   "authors": [
     "Nicolas Bevacqua <nicolasbevacqua@gmail.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "localstorage",
   "main": "dist/local-storage.js",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "homepage": "https://github.com/bevacqua/local-storage",
   "authors": [
     "Nicolas Bevacqua <nicolasbevacqua@gmail.com>"

--- a/changelog.markdown
+++ b/changelog.markdown
@@ -1,3 +1,7 @@
+# 1.4.3
+
+Make it work inside iframe (where localStorage doesn't work cross domains, so we use stub)
+
 # 1.4.2 Keyboard Smasher
 
 Fixed a bug where `local-storage` wouldn't retrieve any values unless they had a `'key'` key

--- a/changelog.markdown
+++ b/changelog.markdown
@@ -1,4 +1,8 @@
-# 1.4.1
+# 1.4.2 Keyboard Smasher
+
+Fixed a bug where `local-storage` wouldn't retrieve any values unless they had a `'key'` key
+
+# 1.4.1 Bear Hunt
 
 Fix a bug where `local-storage` would throw in IE when using the `file://` protocol
 

--- a/dist/local-storage.js
+++ b/dist/local-storage.js
@@ -4,7 +4,19 @@
 
 var stub = require('./stub');
 var tracking = require('./tracking');
-var ls = 'localStorage' in global && global.localStorage ? global.localStorage : stub;
+var inIframe = global && global.top !== global;
+
+var localStorageAvailable = (function () {
+  try {
+    global.localStorage.setItem('test', 'test');
+    global.localStorage.removeItem('test');
+    return true;
+  } catch (e) {
+    return false;
+  }
+});
+
+var ls = !inIframe && localStorageAvailable() ? global.localStorage : stub;
 
 function accessor (key, value) {
   if (arguments.length === 1) {

--- a/dist/local-storage.js
+++ b/dist/local-storage.js
@@ -50,7 +50,7 @@ module.exports = accessor;
 var ms = {};
 
 function getItem (key) {
-  return 'key' in ms ? ms[key] : null;
+  return key in ms ? ms[key] : null;
 }
 
 function setItem (key, value) {

--- a/dist/local-storage.js
+++ b/dist/local-storage.js
@@ -4,19 +4,18 @@
 
 var stub = require('./stub');
 var tracking = require('./tracking');
-var inIframe = global && global.top !== global;
 
-var localStorageAvailable = (function () {
+var localStorageAvailable = function () {
   try {
-    global.localStorage.setItem('test', 'test');
-    global.localStorage.removeItem('test');
+    global.localStorage.setItem('_test-local-storage-availability_', '1');
+    global.localStorage.removeItem('_test-local-storage-availability_');
     return true;
   } catch (e) {
     return false;
   }
-});
+};
 
-var ls = !inIframe && localStorageAvailable() ? global.localStorage : stub;
+var ls = localStorageAvailable() ? global.localStorage : stub;
 
 function accessor (key, value) {
   if (arguments.length === 1) {

--- a/local-storage.js
+++ b/local-storage.js
@@ -2,19 +2,18 @@
 
 var stub = require('./stub');
 var tracking = require('./tracking');
-var inIframe = global && global.top !== global;
 
-var localStorageAvailable = (function () {
+var localStorageAvailable = function () {
   try {
-    global.localStorage.setItem('test', 'test');
-    global.localStorage.removeItem('test');
+    global.localStorage.setItem('_test-local-storage-availability_', '1');
+    global.localStorage.removeItem('_test-local-storage-availability_');
     return true;
   } catch (e) {
     return false;
   }
-});
+};
 
-var ls = !inIframe && localStorageAvailable() ? global.localStorage : stub;
+var ls = localStorageAvailable() ? global.localStorage : stub;
 
 function accessor (key, value) {
   if (arguments.length === 1) {

--- a/local-storage.js
+++ b/local-storage.js
@@ -2,7 +2,19 @@
 
 var stub = require('./stub');
 var tracking = require('./tracking');
-var ls = 'localStorage' in global && global.localStorage ? global.localStorage : stub;
+var inIframe = global && global.top !== global;
+
+var localStorageAvailable = (function () {
+  try {
+    global.localStorage.setItem('test', 'test');
+    global.localStorage.removeItem('test');
+    return true;
+  } catch (e) {
+    return false;
+  }
+});
+
+var ls = !inIframe && localStorageAvailable() ? global.localStorage : stub;
 
 function accessor (key, value) {
   if (arguments.length === 1) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-storage",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A simplified localStorage API that just works",
   "main": "local-storage.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-storage",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A simplified localStorage API that just works",
   "main": "local-storage.js",
   "repository": {


### PR DESCRIPTION
Local storage doesn't work in iframe when iframe is loaded cross domains. Additionally, any call to `window.localStorage` throws an error. Which means that current way of check if localStorage is available would break. 

This PR introduces a more robust way of checking.